### PR TITLE
Trivia for UMP-45

### DIFF
--- a/lua/weapons/arc9_go_ump.lua
+++ b/lua/weapons/arc9_go_ump.lua
@@ -12,11 +12,11 @@ SWEP.TrueName = "UMP-45"
 SWEP.Class = "Submachine Gun"
 SWEP.Trivia = {
     ["Country of Origin"] = "United States of America",
-    ["Caliber"] = "5.56 NATO",
-    ["Weight (Loaded)"] = "3.22kg",
-    ["Projectile Weight"] = "4 Grams",
-    ["Muzzle Velocity"] = "2900 Feet/Second",
-    ["Muzzle Energy"] = "1570 Joules"
+    ["Caliber"] = ".45 ACP",
+    ["Weight (Loaded)"] = "3.02kg",
+    ["Projectile Weight"] = "15.2 Grams",
+    ["Muzzle Velocity"] = "853 Feet/Second",
+    ["Muzzle Energy"] = "513 Joules"
 }
 
 SWEP.Credits = {


### PR DESCRIPTION
Projectile weight copied from USP trivia.  Loaded weight calculated from H&K product page; assumes 15.2 grams per round with 25 round magazine. Muzzle velocity per H&K operator's manual. Muzzle energy calculated from 15.2 gram projectile at 260 m/s (Lower than the USP for some reason?)