### PR TITLE
awp+mp7+bizon+2xmp5+scar17+sg556+ump

### DIFF
--- a/lua/arc9/common/attachments_bulk/csgo_arc9_weapon_awp.lua
+++ b/lua/arc9/common/attachments_bulk/csgo_arc9_weapon_awp.lua
@@ -8,7 +8,7 @@ ATT.CompactName = "450mm"
 ATT.Description = [[Bull barrel that significantly reduces recoil, though at the cost of handling.]]
 ATT.SortOrder = 0
 
-ATT.Icon = Material("entities/attachs/go_awp_barrel_long.png", "mips smooth")
+ATT.Icon = Material("entities/attachs/go_awp_barrel_bull.png", "mips smooth")
 ATT.AutoStats = true
 
 ATT.Free = false
@@ -105,6 +105,33 @@ ARC9.LoadAttachment(ATT, "csgo_awp_stock_folding")
 ATT = {}
 
 ATT.MenuCategory = "ARC9 - CSGO Attachments"
+ATT.PrintName = "Obrez stock"
+ATT.CompactName = "Obrez"
+ATT.Description = [[Removes the stock of the weapon.
+Lightweight stock that improves handling at the cost of recoil control.]]
+
+ATT.Icon = Material("entities/attachs/go_awp_stock_obrez.png", "mips smooth")
+
+--ATT.Model = "models/weapons/csgo/atts/grip_vertical.mdl"
+
+ATT.SortOrder = 0
+ATT.Category = "go_stock_awp"
+ATT.ActivateElements = {"stock_none"}
+
+ATT.SprintToFireTimeMult = 0.85
+ATT.AimDownSightsTimeMult = 0.85
+
+ATT.RecoilMult = 1.15
+ATT.VisualRecoilMult = 1.15
+ATT.RecoilKickMult = 1.15
+
+ATT.RecoilAutoControlMult = 0.8
+
+ARC9.LoadAttachment(ATT, "csgo_awp_stock_obrez")
+
+ATT = {}
+
+ATT.MenuCategory = "ARC9 - CSGO Attachments"
 ATT.PrintName = [[15-Round .338 AWM]]
 ATT.CompactName = [[15-Round]]
 ATT.Icon = Material("entities/attachs/go_awp_mag_15.png")
@@ -167,10 +194,10 @@ ATT.ActivateElements = {"sight_iron"}
 
 ATT.Sights = {
     {
-        Pos = Vector(-0, 15, -1),
-        Ang = Angle(0, -0.5, 0),
+        Pos = Vector(0.025, 9, -0.85),
+        Ang = Angle(0, -0, 0),
         Magnification = 1.15,
-        ViewModelFOV = 40,
+        ViewModelFOV = 60,
         IgnoreExtra = false
     },
 }

--- a/lua/arc9/common/attachments_bulk/csgo_arc9_weapon_mp7.lua
+++ b/lua/arc9/common/attachments_bulk/csgo_arc9_weapon_mp7.lua
@@ -88,8 +88,8 @@ ATT.ActivateElements = {"mount"}
 
 ATT.Sights = {
     {
-        Pos = Vector(0, 9, -0.4),
-        Ang = Angle(0, 1.5, 0),
+        Pos = Vector(0, 9, -0.35),
+        Ang = Angle(0, 1.25, 0),
         Reticle = nil, -- Same as ATT.RTScopeReticle or HoloSightReticle but this sight only. Better cache material somewhere outside this structure: local Reticle1 = Material("reticle1.png", "mips smooth") and here you type only Reticle1). If not defined, will use ATT.RTScopeReticle/HoloSightReticle
 
 

--- a/lua/weapons/arc9_go_bizon.lua
+++ b/lua/weapons/arc9_go_bizon.lua
@@ -188,8 +188,8 @@ SWEP.TracerColor = Color(255, 255, 155) -- Color of tracers. Only works if trace
 -------------------------- POSITIONS
 
 SWEP.IronSights = {
-    Pos = Vector(-5.11, -8, 0.575),
-    Ang = Angle(0, 0.8, -1.25),
+    Pos = Vector(-5.11, -8, 1),
+    Ang = Angle(0, 0, -1.25),
     Magnification = 1.25,
     ViewModelFOV = 56,
 }

--- a/lua/weapons/arc9_go_mp5.lua
+++ b/lua/weapons/arc9_go_mp5.lua
@@ -520,6 +520,11 @@ SWEP.AttachmentElements = {
             {4,3},
         },
     },
+	["mag2"] = {
+        Bodygroups = {
+            {4,1},
+        },
+    },
     ["stock_retract"] = {
         Bodygroups = {
             {5,1},
@@ -544,7 +549,10 @@ SWEP.AttachmentElements = {
 	["mag_k"] = { Bodygroups = { {4,2}, }, },
     ["hg_k"] = {
 		Bodygroups = { {0,1}, },
-		AttPosMods = { [1] = { Pos = Vector(0, -3.91, 14), } }	
+		AttPosMods = { 
+		[1] = { Pos = Vector(0, -3.91, 14), }, 
+		[4] = { Pos = Vector(-1, -3.95, 8), } 
+		}		
 	},	
 }
 
@@ -577,9 +585,9 @@ SWEP.Attachments = {
     {
         PrintName = ARC9:GetPhrase("csgo_category_top"),
         Bone = "v_weapon.MP5_Parent",
-        Pos = Vector(0, -5.2, 3.15),
+        Pos = Vector(0, -5.2, 3.75),
         Ang = Angle(90, 0, -90),
-        Category = {"csgo_rail_optic",},
+        Category = {"csgo_rail_optic","csgo_optic_g3sg1"},
         InstalledElements = {"rearsight"},
         CorrectiveAng = Angle(-0.05, -0.03, 0),
     },

--- a/lua/weapons/arc9_go_mp5sd.lua
+++ b/lua/weapons/arc9_go_mp5sd.lua
@@ -524,6 +524,11 @@ SWEP.AttachmentElements = {
             {2,2},
         },
     },
+	["mag2"] = {
+        Bodygroups = {
+            {2,1},
+        },
+    },
     ["mag_none"] = {
         Bodygroups = {
             {2,3},
@@ -597,9 +602,9 @@ SWEP.Attachments = {
     {
         PrintName = ARC9:GetPhrase("csgo_category_top"),
         Bone = "v_weapon.mp5sd_parent",
-        Pos = Vector(0, 3.7, 5),
+        Pos = Vector(0, 4.25, 5),
         Ang = Angle(0, -90, 0),
-        Category = {"csgo_rail_optic",},
+        Category = {"csgo_rail_optic","csgo_optic_g3sg1"},
         CorrectiveAng = Angle(0.2, 0.15, 0),
     },
     {

--- a/lua/weapons/arc9_go_scar17.lua
+++ b/lua/weapons/arc9_go_scar17.lua
@@ -616,7 +616,7 @@ SWEP.Attachments = {
     },
     {
         PrintName = ARC9:GetPhrase("csgo_category_perk"),
-        Category = "go_perk",
+        Category = {"go_perk", "go_perk_burst"},
         Bone = "v_weapon.SCAR_Parent",
         Pos = Vector(0, 2, 6),
     },

--- a/lua/weapons/arc9_go_sg556.lua
+++ b/lua/weapons/arc9_go_sg556.lua
@@ -556,7 +556,7 @@ SWEP.HookP_NameChange = function(self, name)
 	if att["csgo_sg556_barrel_short"] then
         name = ARC9:GetPhrase("csgo_weapon_sg556_sg552")
     end
-	if att["csgo_sg556_barrel_proto"] then
+	if att["csgo_sg556_barrel_proto"] and att["csgo_sg556_stock_proto"] then
         name = ARC9:GetPhrase("csgo_weapon_sg556_sg541")
     end
 

--- a/lua/weapons/arc9_go_ump.lua
+++ b/lua/weapons/arc9_go_ump.lua
@@ -429,6 +429,7 @@ SWEP.AttachmentElements = {
         Bodygroups = {
             {1,1},
         },
+    AttPosMods = { [3] = { Pos = Vector(0, -3.95, 17.5), } }
     },
     ["barrel_long"] = {
         Bodygroups = {


### PR DESCRIPTION
Changes:
- Changed Bull-barrel icon to the _real_ one
- Added Obrez stock for AWP
- Changed PDW ironsights for MP7
![image](https://github.com/CurlySparkle/ARC9-GSR/assets/54255077/478ee3bb-c9f8-4f9f-87a9-9f9c25c2c74c)
- Changed ironsights for Bizon
![image](https://github.com/CurlySparkle/ARC9-GSR/assets/54255077/bac05fc5-b6c0-4eb1-8fca-61adf383a940)
- Added mag2 elements for MP5s (this is a surprise tool that will help us later)
- Added G3 scope to MP5s and moved the attachment forward to match the G3
- Fixed tactical mount on MP5k
![image](https://github.com/CurlySparkle/ARC9-GSR/assets/54255077/2bff1da0-fcd6-4eba-b139-45636787301e)
- Added burst to the SCAR17 to match the description.
- Added stock requirement for SG541 name
- Fixed muzzle on H&K UMP45 barrel not changing